### PR TITLE
Update refresh button to use emoji and resize

### DIFF
--- a/workspace_explorer.py
+++ b/workspace_explorer.py
@@ -34,7 +34,8 @@ class WorkspaceExplorer(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # 创建刷新按钮
-        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button = QPushButton("🔄")
+        self.refresh_button.setFixedSize(30, 30)
         self.refresh_button.clicked.connect(self.refresh_file_tree)
         layout.addWidget(self.refresh_button) # Add button to layout
 


### PR DESCRIPTION
I replaced the text 'Refresh' on the workspace explorer's refresh button with the '🔄' emoji. The button size has also been fixed to 30x30 pixels for a more compact UI.