### PR TITLE
Fix: Correct commit hashes for CompareWithWorkingDialog

### DIFF
--- a/compare_with_working_dialog.py
+++ b/compare_with_working_dialog.py
@@ -6,13 +6,14 @@ from text_diff_viewer import DiffViewer
 
 
 class CompareWithWorkingDialog(QDialog):
-    def __init__(self, title, old_content, new_content, file_path, parent=None):
+    def __init__(self, title, old_content, new_content, file_path, left_commit_hash_for_old_content: str, parent=None):
         super().__init__(parent)
         self.setWindowTitle(title)
         self.resize(800, 600)
+        self.left_commit_hash = left_commit_hash_for_old_content
 
         layout = QVBoxLayout(self)
         self.diff_viewer = DiffViewer()
         layout.addWidget(self.diff_viewer)
 
-        self.diff_viewer.set_texts(old_content, new_content, file_path, None, None)
+        self.diff_viewer.set_texts(old_content, new_content, file_path, self.left_commit_hash, None)

--- a/text_diff_viewer.py
+++ b/text_diff_viewer.py
@@ -140,6 +140,7 @@ class DiffViewer(QWidget):
 
     def set_texts(self, left_text: str, right_text: str, file_path: str, left_commit_hash: Optional[str], right_commit_hash: Optional[str]):
         """设置要比较的文本"""
+        logging.info(f"DiffViewer.set_texts called. left_commit_hash: {left_commit_hash} (type: {type(left_commit_hash)}), right_commit_hash: {right_commit_hash} (type: {type(right_commit_hash)})")
         logging.debug("\n=== 设置新的文本进行比较 ===")
         # 先设置文本
         self.left_edit.setPlainText(left_text)
@@ -414,6 +415,7 @@ class MergeDiffViewer(DiffViewer):
 
     def set_texts(self, parent1_text: str, result_text: str, parent2_text: str, file_path: str, parent1_commit_hash: Optional[str], result_commit_hash: Optional[str], parent2_commit_hash: Optional[str]):
         """设置要比较的三个文本"""
+        logging.info(f"MergeDiffViewer.set_texts called. parent1_commit_hash: {parent1_commit_hash} (type: {type(parent1_commit_hash)}), result_commit_hash: {result_commit_hash} (type: {type(result_commit_hash)}), parent2_commit_hash: {parent2_commit_hash} (type: {type(parent2_commit_hash)})")
         logging.debug("\n=== 设置新的三向文本进行比较 ===")
         # 设置文本
         self.parent1_edit.setPlainText(parent1_text)


### PR DESCRIPTION
- Modified CompareWithWorkingDialog to accept and use the actual commit hash for the 'old_content' side of the diff.
- Updated GitManagerWindow to pass the current commit's hexsha when opening the CompareWithWorkingDialog.
- The DiffViewer.set_texts call in this dialog now correctly uses (actual_commit_hash, None) for its commit hash parameters, resolving the issue where (None, None) was previously used.