### PR TITLE
feat: Add context menu and shortcuts for text editing

### DIFF
--- a/editors/text_edit.py
+++ b/editors/text_edit.py
@@ -178,6 +178,30 @@ class SyncedTextEdit(QPlainTextEdit):
         ):
             self.open_find_dialog()
             event.accept()  # Indicate that the event has been handled
+        # 全选快捷键 (Ctrl+A 或 Cmd+A)
+        elif event.key() == Qt.Key.Key_A and (
+            event.modifiers() == Qt.KeyboardModifier.ControlModifier
+            or event.modifiers() == Qt.KeyboardModifier.MetaModifier
+        ):
+            self.select_all_text()
+            event.accept()
+        # 复制快捷键 (Ctrl+C 或 Cmd+C)
+        elif event.key() == Qt.Key.Key_C and (
+            event.modifiers() == Qt.KeyboardModifier.ControlModifier
+            or event.modifiers() == Qt.KeyboardModifier.MetaModifier
+        ):
+            self.copy_text()
+            event.accept()
+        # 粘贴快捷键 (Ctrl+V 或 Cmd+V)
+        elif event.key() == Qt.Key.Key_V and (
+            event.modifiers() == Qt.KeyboardModifier.ControlModifier
+            or event.modifiers() == Qt.KeyboardModifier.MetaModifier
+        ):
+            if not self.isReadOnly():
+                self.paste_text()
+                event.accept()
+            else:
+                super().keyPressEvent(event) # Allow paste to work in read-only mode if underlying widget supports it
         else:
             super().keyPressEvent(event)  # Call base class implementation for other keys
 
@@ -282,6 +306,19 @@ class SyncedTextEdit(QPlainTextEdit):
     def show_context_menu(self, position):
         menu = QMenu(self)
 
+        select_all_action = menu.addAction("Select All")
+        select_all_action.triggered.connect(self.select_all_text)
+
+        copy_action = menu.addAction("Copy")
+        copy_action.triggered.connect(self.copy_text)
+
+        paste_action = menu.addAction("Paste")
+        paste_action.triggered.connect(self.paste_text)
+        if self.isReadOnly():
+            paste_action.setEnabled(False)
+
+        menu.addSeparator()
+
         # if self.isReadOnly() or not self.blame_annotations_per_line:
         blame_action = menu.addAction("Show Blame")
         blame_action.triggered.connect(self.show_blame)
@@ -295,6 +332,21 @@ class SyncedTextEdit(QPlainTextEdit):
 
     # Renamed from _show_context_menu to show_context_menu for consistency
     # No other change in this method, just ensuring the diff picks up the rename if any confusion.
+
+    def select_all_text(self):
+        # Placeholder for select all functionality
+        logging.debug("Select All action triggered")
+        self.selectAll()
+
+    def copy_text(self):
+        # Placeholder for copy functionality
+        logging.debug("Copy action triggered")
+        self.copy()
+
+    def paste_text(self):
+        # Placeholder for paste functionality
+        logging.debug("Paste action triggered")
+        self.paste()
 
     def set_editable(self):
         """将文本编辑设置为可编辑模式并保存原始内容"""


### PR DESCRIPTION
I've added "Select All", "Copy", and "Paste" functionalities to the SyncedTextEdit widget in `editors/text_edit.py`.

My changes include:
- I updated `show_context_menu` to include "Select All", "Copy", and "Paste" actions. The "Paste" action is disabled if the editor is in read-only mode.
- I added corresponding handler methods (`select_all_text`, `copy_text`, `paste_text`) that utilize the built-in QPlainTextEdit actions.
- I modified `keyPressEvent` to support standard keyboard shortcuts:
    - Ctrl+A (Cmd+A on macOS) for Select All.
    - Ctrl+C (Cmd+C on macOS) for Copy.
    - Ctrl+V (Cmd+V on macOS) for Paste (only enabled when not read-only).

These changes enhance the usability of the text editor by providing common editing operations through both the context menu and keyboard shortcuts.