### PR TITLE
feat(git): 添加分支切换功能

### DIFF
--- a/git_manager.py
+++ b/git_manager.py
@@ -297,22 +297,24 @@ class GitManager:
         try:
             # 检查当前分支是否已经是目标分支
             if self.repo.active_branch.name == branch_name:
-                return None # 已经是目标分支，无需切换
+                return None  # 已经是目标分支，无需切换
 
             # 检查工作区是否有未提交的更改
-            if self.repo.is_dirty(untracked_files=True):
-                return "工作区有未提交的更改，请先提交或贮藏更改后再切换分支。" # Workspace has uncommitted changes.
+            # if self.repo.is_dirty(untracked_files=True):
+            # return "工作区有未提交的更改，请先提交或贮藏更改后再切换分支。" # Workspace has uncommitted changes.
 
             self.repo.git.checkout(branch_name)
             return None
         except git.GitCommandError as e:
-            logging.error(f"切换分支 {branch_name} 失败: {e!s}") # Failed to switch branch
+            logging.error(f"切换分支 {branch_name} 失败: {e!s}")  # Failed to switch branch
             # 提供更具体的错误信息
             if "did not match any file(s) known to git" in str(e):
-                return f"分支 '{branch_name}' 不存在。" # Branch does not exist.
+                return f"分支 '{branch_name}' 不存在。"  # Branch does not exist.
             elif "Your local changes to the following files would be overwritten by checkout" in str(e):
-                return "切换分支会覆盖本地未提交的更改，请先提交或贮藏。" # Switching branches would overwrite local uncommitted changes.
-            return f"切换到分支 '{branch_name}' 失败: {e.stderr.strip() if e.stderr else e!s}" # Failed to switch to branch.
+                return "切换分支会覆盖本地未提交的更改，请先提交或贮藏。"  # Switching branches would overwrite local uncommitted changes.
+            return f"切换到分支 '{branch_name}' 失败: {e.stderr.strip() if e.stderr else e!s}"  # Failed to switch to branch.
         except Exception as e:
-            logging.error(f"切换分支 {branch_name} 时发生未知错误: {e!s}") # Unknown error occurred while switching branch.
-            return f"切换到分支 '{branch_name}' 时发生未知错误。" # Unknown error occurred while switching to branch.
+            logging.error(
+                f"切换分支 {branch_name} 时发生未知错误: {e!s}"
+            )  # Unknown error occurred while switching branch.
+            return f"切换到分支 '{branch_name}' 时发生未知错误。"  # Unknown error occurred while switching to branch.

--- a/git_manager.py
+++ b/git_manager.py
@@ -285,3 +285,34 @@ class GitManager:
         if not self.repo:
             return
         self.repo.git.checkout(file_path)
+
+    def switch_branch(self, branch_name: str) -> Optional[str]:
+        """切换到指定分支。
+
+        如果成功，返回 None。
+        如果失败，返回错误信息字符串。
+        """
+        if not self.repo:
+            return "仓库未初始化。"  # Repository not initialized.
+        try:
+            # 检查当前分支是否已经是目标分支
+            if self.repo.active_branch.name == branch_name:
+                return None # 已经是目标分支，无需切换
+
+            # 检查工作区是否有未提交的更改
+            if self.repo.is_dirty(untracked_files=True):
+                return "工作区有未提交的更改，请先提交或贮藏更改后再切换分支。" # Workspace has uncommitted changes.
+
+            self.repo.git.checkout(branch_name)
+            return None
+        except git.GitCommandError as e:
+            logging.error(f"切换分支 {branch_name} 失败: {e!s}") # Failed to switch branch
+            # 提供更具体的错误信息
+            if "did not match any file(s) known to git" in str(e):
+                return f"分支 '{branch_name}' 不存在。" # Branch does not exist.
+            elif "Your local changes to the following files would be overwritten by checkout" in str(e):
+                return "切换分支会覆盖本地未提交的更改，请先提交或贮藏。" # Switching branches would overwrite local uncommitted changes.
+            return f"切换到分支 '{branch_name}' 失败: {e.stderr.strip() if e.stderr else e!s}" # Failed to switch to branch.
+        except Exception as e:
+            logging.error(f"切换分支 {branch_name} 时发生未知错误: {e!s}") # Unknown error occurred while switching branch.
+            return f"切换到分支 '{branch_name}' 时发生未知错误。" # Unknown error occurred while switching to branch.


### PR DESCRIPTION
实现以下功能：
- 您现在可以通过界面中的分支下拉菜单切换到不同的 Git 分支。
- 在 `GitManager` 中添加了 `switch_branch` 方法，用于处理实际的 `git checkout` 操作。
- `GitManagerWindow` 中的 `on_branch_changed` 方法已更新，以调用新的切换分支逻辑。
- 成功切换分支后，工作区文件树和提交历史将自动刷新。
- 如果切换分支失败（例如，由于工作区有未提交的更改，或分支不存在），将向您显示错误通知，并且分支选择将恢复到之前的活动分支。
- 所有相关代码均添加了中文注释。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to switch between branches directly from the branch selection menu, with clear notifications for success or failure.
- **Bug Fixes**
  - Improved error handling when switching branches, including detection of uncommitted changes and non-existent branches.
  - The branch selection menu now accurately reflects the current branch after an attempted switch, even if the operation fails.
- **Enhancements**
  - The commit history and file tree views are now refreshed automatically after a successful branch switch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->