### PR TITLE
Fix: Remove borders from sidebar buttons

### DIFF
--- a/side_bar_widget.py
+++ b/side_bar_widget.py
@@ -22,6 +22,7 @@ class SideBarWidget(QWidget):
         self.project_btn.setText("工程")
         self.project_btn.setIcon(QIcon("icons/project.svg"))
         self.project_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
+        self.project_btn.setStyleSheet("border: none;")
         self.project_btn.clicked.connect(self.project_button_clicked.emit)
         layout.addWidget(self.project_btn)
 
@@ -30,6 +31,7 @@ class SideBarWidget(QWidget):
         self.commit_btn.setText("提交")
         self.commit_btn.setIcon(QIcon("icons/commit_icon.svg"))
         self.commit_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
+        self.commit_btn.setStyleSheet("border: none;")
         self.commit_btn.clicked.connect(self.commit_button_clicked.emit)
         layout.addWidget(self.commit_btn)
 


### PR DESCRIPTION
This change removes the borders from the 'Project' and 'Commit' buttons in the sidebar to match the desired UI style.