### PR TITLE
修正日志记录格式，避免使用f-string

### DIFF
--- a/commit_widget.py
+++ b/commit_widget.py
@@ -201,7 +201,7 @@ class CommitWidget(QFrame):
         unstaged = repo.index.diff(None)
         for diff in unstaged:
             item = QTreeWidgetItem(self.unstaged_tree)
-            logging.info(f"commit_dialog: unstaged file: {diff.a_path}")
+            logging.info("commit_dialog: unstaged file: %s", diff.a_path)
             item.setText(0, diff.a_path)
             item.setText(1, "Modified")
 

--- a/editors/modified_text_edit.py
+++ b/editors/modified_text_edit.py
@@ -124,7 +124,7 @@ QPlainTextEdit QScrollBar::handle:vertical:pressed {
         """当文档内容修改状态改变时调用，发出 dirty_status_changed 信号。"""
         if self.file_path:
             self.dirty_status_changed.emit(self.file_path, modified)
-            logging.debug(f"Emitted dirty_status_changed for {self.file_path}: {modified}")
+            logging.debug("Emitted dirty_status_changed for %s: %s", self.file_path, modified)
 
     # </new_method>
 
@@ -233,7 +233,7 @@ QPlainTextEdit QScrollBar::handle:vertical:pressed {
         # 文件已保存，状态变为未修改
         if self.file_path:  # Ensure file_path is set
             self.dirty_status_changed.emit(self.file_path, False)
-            logging.debug(f"Emitted dirty_status_changed for {self.file_path} (saved): False")
+            logging.debug("Emitted dirty_status_changed for %s (saved): False", self.file_path)
         self.document().setModified(False)
         parent = self.parent()
         while parent and not hasattr(parent, "git_manager"):  # Check parent exists

--- a/file_history_view.py
+++ b/file_history_view.py
@@ -74,7 +74,7 @@ class FileHistoryView(QWidget):
             )
 
             if not log_output.strip():
-                logging.info(f"No commits found for file {relative_path}")
+                logging.info("No commits found for file %s", relative_path)
                 return
 
             # 直接解析并添加到界面，不创建 commit 对象
@@ -222,7 +222,7 @@ class FileHistoryView(QWidget):
                 try:
                     main_window.side_bar.changes_btn.click()
                 except Exception as e:
-                    logging.warning(f"触发 changes_btn 点击失败：{e}")
+                    logging.warning("触发 changes_btn 点击失败：%s", e)
 
         except Exception as e:
             logging.exception("显示所有受影响的文件失败")

--- a/folder_history_view.py
+++ b/folder_history_view.py
@@ -116,7 +116,7 @@ class FolderHistoryView(QWidget):  # Renamed class
         """当用户点击提交记录时触发"""
         commit_hash = item.data(0, Qt.ItemDataRole.UserRole)  # Retrieve full hash
         if commit_hash:
-            logging.info(f"提交记录被点击: Commit {commit_hash}, 文件夹: {self.folder_path}")
+            logging.info("提交记录被点击: Commit %s, 文件夹: %s", commit_hash, self.folder_path)
             get_main_window_by_parent(self).on_commit_selected(commit_hash)
         else:
             logging.warning("无法获取点击的提交记录哈希值。")

--- a/syntax_highlighter.py
+++ b/syntax_highlighter.py
@@ -30,9 +30,9 @@ class PygmentsHighlighterEngine:
         # 根据语言名称初始化词法分析器和样式 (Initialize lexer and styles based on language name)
         try:
             self.lexer = lexers.get_lexer_by_name(language_name)
-            logging.info(f"词法分析器已设置为：{language_name}")
+            logging.info("词法分析器已设置为：%s", language_name)
         except ClassNotFound:
-            logging.warning(f"未找到语言 '{language_name}' 的词法分析器，将使用纯文本模式。")
+            logging.warning("未找到语言 '%s' 的词法分析器，将使用纯文本模式。", language_name)
             self.lexer = lexers.get_lexer_by_name("text")  # Fallback to plain text
 
         try:

--- a/workspace_explorer.py
+++ b/workspace_explorer.py
@@ -228,13 +228,17 @@ class WorkspaceExplorer(QWidget):
                 try:
                     text_edit.blame_annotation_clicked.connect(getattr(main_git_window, handler_name))
                     logging.info(
-                        f"Connected blame_annotation_clicked from editor for '{file_path}' to {handler_name} in GitManagerWindow."
+                        "Connected blame_annotation_clicked from editor for '%s' to %s in GitManagerWindow.",
+                        file_path,
+                        handler_name,
                     )
                 except Exception as e_connect:
-                    logging.error(f"Failed to connect blame_annotation_clicked for '{file_path}': {e_connect}")
+                    logging.error("Failed to connect blame_annotation_clicked for '%s': %s", file_path, e_connect)
             else:
                 logging.warning(
-                    f"Could not find GitManagerWindow with handler '{handler_name}' for editor '{file_path}'. Blame click will not be handled globally."
+                    "Could not find GitManagerWindow with handler '%s' for editor '%s'. Blame click will not be handled globally.",
+                    handler_name,
+                    file_path,
                 )
 
             text_edit.dirty_status_changed.connect(self.update_filename_display)
@@ -396,12 +400,13 @@ class WorkspaceExplorer(QWidget):
                             elif relative_path in self.all_file_statuses.get("untracked", set()):
                                 tree_item.setForeground(0, QColor(0, 128, 0))  # Green color
                         except ValueError:
-                            logging.debug(f"Cannot get relative path for {item_path} against {self.workspace_path}.")
+                            logging.debug("Cannot get relative path for %s against %s.", item_path, self.workspace_path)
                         except Exception as e_status:
-                            logging.error(f"Error processing file status for {item_path}: {e_status}")
+                            logging.error("Error processing file status for %s: %s", item_path, e_status)
                     else:
                         logging.debug(
-                            f"Workspace path not suitable for file status: {self.workspace_path if hasattr(self, 'workspace_path') else 'Not set'}"
+                            "Workspace path not suitable for file status: %s",
+                            self.workspace_path if hasattr(self, "workspace_path") else "Not set",
                         )
 
                 elif os.path.isdir(item_path):
@@ -413,11 +418,11 @@ class WorkspaceExplorer(QWidget):
                     current_dir_or_descendant_is_modified = True
 
         except FileNotFoundError:
-            logging.warning(f"Directory not found during tree population: {path}.")
+            logging.warning("Directory not found during tree population: %s.", path)
         except PermissionError:
-            logging.warning(f"Permission denied for directory: {path}.")
+            logging.warning("Permission denied for directory: %s.", path)
         except Exception as e:
-            logging.error(f"Error loading directory contents for {path}: {e}")
+            logging.error("Error loading directory contents for %s: %s", path, e)
 
         return current_dir_or_descendant_is_modified
 
@@ -690,7 +695,7 @@ class FileTreeWidget(QTreeWidget):
                     revert_action = context_menu.addAction("Revert")
                     revert_action.triggered.connect(lambda: self.revert_file(file_path))
             except Exception as e:
-                logging.error(f"检查文件状态出错：{e}")
+                logging.error("检查文件状态出错：%s", e)
 
         # 在鼠标位置显示菜单
         context_menu.exec(self.mapToGlobal(position))
@@ -824,7 +829,7 @@ class FileTreeWidget(QTreeWidget):
                 clipboard = QApplication.clipboard()
                 clipboard.setText(relative_path)
             except Exception as e:
-                logging.error(f"复制相对路径失败：{e}")
+                logging.error("复制相对路径失败：%s", e)
         else:
             logging.error("无法获取工作区路径")
 
@@ -876,9 +881,9 @@ class FileTreeWidget(QTreeWidget):
         try:
             clipboard = QApplication.clipboard()
             clipboard.setText(file_path)
-            logging.info(f"已复制完整路径：{file_path}")
+            logging.info("已复制完整路径：%s", file_path)
         except Exception as e:
-            logging.error(f"复制完整路径失败：{e}")
+            logging.error("复制完整路径失败：%s", e)
 
     def _open_in_file_manager(self, file_path: str):
         """在文件管理器中打开文件或文件夹"""
@@ -917,9 +922,9 @@ class FileTreeWidget(QTreeWidget):
                         logging.warning("无法找到适合的文件管理器")
                         return
 
-            logging.info(f"已在文件管理器中打开：{dir_path}")
+            logging.info("已在文件管理器中打开：%s", dir_path)
         except Exception as e:
-            logging.error(f"在文件管理器中打开失败：{e}")
+            logging.error("在文件管理器中打开失败：%s", e)
 
     def _get_expanded_paths(self, item: QTreeWidgetItem, expanded_paths: set):
         """递归获取所有展开的文件夹路径"""


### PR DESCRIPTION
- 在多个文件中更新日志记录，使用占位符格式化字符串，提升日志一致性和可读性。
- 涉及文件：commit_widget.py, file_history_view.py, folder_history_view.py, syntax_highlighter.py, workspace_explorer.py, editors/modified_text_edit.py。