### PR TITLE
fix(blame): 修复 blame 点击无法选中 commit 的问题

### DIFF
--- a/tests/test_blame_annotation_click.py
+++ b/tests/test_blame_annotation_click.py
@@ -1,10 +1,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication
 
-# CommitHistoryView is used by GitManagerWindow, but we directly interact with window.commit_history_view
-# from commit_history_view import CommitHistoryView
 from git_manager import GitManager
 
 # Application imports

--- a/tests/test_blame_annotation_click.py
+++ b/tests/test_blame_annotation_click.py
@@ -128,7 +128,10 @@ class TestBlameAnnotationClick(unittest.TestCase):
         # 6. Verify Commit Selection
         current_item = window.commit_history_view.history_list.currentItem()
         self.assertIsNotNone(current_item, "No item selected after blame click")
-        self.assertEqual(current_item.text(0), short_target_hash, "Incorrect commit selected")
+        # 检查 UserRole 中的哈希前缀，因为 text(0) 现在是提交消息
+        self.assertTrue(
+            current_item.data(0, Qt.ItemDataRole.UserRole).startswith(short_target_hash), "Incorrect commit selected"
+        )
 
         expected_loaded_count = initial_load_batch_size * 2
         self.assertEqual(
@@ -228,7 +231,10 @@ class TestBlameAnnotationClick(unittest.TestCase):
         # 6. Verify Commit Selection
         current_item = window.commit_history_view.history_list.currentItem()
         self.assertIsNotNone(current_item, "No item selected after blame click")
-        self.assertEqual(current_item.text(0), short_target_hash, "Incorrect commit selected")
+        # 检查 UserRole 中的哈希前缀，因为 text(0) 现在是提交消息
+        self.assertTrue(
+            current_item.data(0, Qt.ItemDataRole.UserRole).startswith(short_target_hash), "Incorrect commit selected"
+        )
 
         # All commits should now be loaded
         self.assertEqual(


### PR DESCRIPTION
在 GitManagerWindow 中处理 blame 点击事件时，提交项的搜索逻辑
错误地依赖于 item.text(0)（原为短哈希，后改为提交信息）。

此提交将搜索逻辑修改为从 item.data(Qt.ItemDataRole.UserRole)
获取完整的哈希值，并比较其前缀，从而确保在 blame 注释被点击时
能够正确找到并选中对应的 commit。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when locating and highlighting commits in the history list after clicking a blame annotation, ensuring more accurate matching and better handling when not all commits are initially loaded.
  * Enhanced commit selection accuracy by updating how commit information is matched and displayed after blame clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->